### PR TITLE
Fix issue #47: [Plan] BasicSelect コンポーネントのサンプルページ追加計画

### DIFF
--- a/tasks/BasicSelect.md
+++ b/tasks/BasicSelect.md
@@ -28,6 +28,8 @@ BasicSelect コンポーネント（client/common/components/inputs/Selects/Basi
 ## 実装例
 ### sample-select/page.tsx
 ```tsx
+'use client';
+
 import React, { useState } from 'react';
 import BasicSelect from 'client/common/components/inputs/Selects/BasicSelect';
 


### PR DESCRIPTION
This pull request introduces a plan to add a sample page demonstrating the usage of the `BasicSelect` component. The changes include creating a new sample page, updating the menu for navigation, and providing implementation details and examples.

### Additions related to the `BasicSelect` component:
* A new sample page (`client/nextjs-sample/app/sample-select/page.tsx`) will be created to showcase the `BasicSelect` component with key props (`label`, `options`, `value`, `onChange`) and demonstrate its functionality. The page will include a state-managed example where the selected value is displayed on the screen.
* The navigation menu in `client/nextjs-sample/app/layout.tsx` will be updated to include a link to the new sample page, enabling users to access it via the app's menu.