### PR TITLE
Fix issue #53: [計画] SimpleTab サンプルページ追加および連携作業計画

### DIFF
--- a/tasks/SimpleTab.md
+++ b/tasks/SimpleTab.md
@@ -1,0 +1,81 @@
+# SimpleTab サンプルページ追加および連携作業計画
+
+## 目的
+- client/common/components/navigations/Tabs/SimpleTab.tsx の使用例を充実させ、利用者の理解を促進する。
+- client/nextjs-sample/app/sample-tab/page.tsx に SimpleTab のサンプルページを新規作成する。
+- client/nextjs-sample/app/layout.tsx の menuItems にサンプルページへのリンクを追加し、遷移を容易にする。
+
+## 調査内容
+1. SimpleTab.tsx の構造と使用方法の確認
+   - コンポーネントの props、状態管理、イベントハンドリングを把握する。
+2. client/nextjs-sample/app/layout.tsx の menuItems の定義場所と形式の確認
+   - どのようにメニュー項目が管理されているかを調査。
+3. Next.js のページ作成方法の確認
+   - app ディレクトリ配下のページ作成ルールを確認。
+
+## 作業計画
+
+### 1. SimpleTab.tsx の使用例作成
+- client/nextjs-sample/app/sample-tab/page.tsx に SimpleTab をインポートし、基本的なタブ切り替えのサンプルを実装。
+- 複数のタブ項目を用意し、選択時の動作を確認できるようにする。
+
+### 2. サンプルページの作成
+- Next.js の app ディレクトリのルールに従い、page.tsx を作成。
+- SimpleTab コンポーネントを利用し、UI と動作のサンプルを表示。
+
+### 3. menuItems へのリンク追加
+- client/nextjs-sample/app/layout.tsx を編集し、menuItems 配列に { label: 'Sample Tab', href: '/sample-tab' } を追加。
+- 既存のメニューと同様の形式で追加し、ナビゲーションに反映させる。
+
+## 実装例
+
+### sample-tab/page.tsx
+```tsx
+import React, { useState } from 'react';
+import SimpleTab from '@/common/components/navigations/Tabs/SimpleTab';
+
+const SampleTabPage = () => {
+  const [activeTab, setActiveTab] = useState('tab1');
+
+  const menuItems = [
+    { id: 'tab1', label: 'Tab 1' },
+    { id: 'tab2', label: 'Tab 2' },
+    { id: 'tab3', label: 'Tab 3' },
+  ];
+
+  return (
+    <div>
+      <h1>SimpleTab サンプルページ</h1>
+      <SimpleTab
+        menuItems={menuItems}
+        activeTab={activeTab}
+        onChange={setActiveTab}
+      />
+      <div style={{ marginTop: 20 }}>
+        {activeTab === 'tab1' && <p>Tab 1 の内容です。</p>}
+        {activeTab === 'tab2' && <p>Tab 2 の内容です。</p>}
+        {activeTab === 'tab3' && <p>Tab 3 の内容です。</p>}
+      </div>
+    </div>
+  );
+};
+
+export default SampleTabPage;
+```
+
+### layout.tsx の menuItems 追加例
+```tsx
+const menuItems = [
+  // 既存のメニュー項目
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about' },
+  // 新規追加
+  { label: 'Sample Tab', href: '/sample-tab' },
+];
+```
+
+## 注意事項
+- 本 issue は計画作成のみのため、tasks/SimpleTab.md 以外のファイルは変更しない。
+- 実装は別 issue で行うこと。
+
+以上。


### PR DESCRIPTION
This pull request adds a detailed plan for creating a sample page for the `SimpleTab` component and integrating it into the navigation menu. The plan outlines the purpose, investigation steps, implementation details, and examples, but no actual code changes are made in this PR.

### Key Changes in the Plan:

#### Sample Page for `SimpleTab` Component:
* A new sample page (`client/nextjs-sample/app/sample-tab/page.tsx`) will be created to demonstrate the usage of the `SimpleTab` component. The example includes basic tab switching functionality with multiple tabs and dynamic content.

#### Navigation Menu Integration:
* The `menuItems` array in `client/nextjs-sample/app/layout.tsx` will be updated to include a link to the new sample page (`{ label: 'Sample Tab', href: '/sample-tab' }`), making it accessible via the navigation menu.

#### Implementation Guidelines:
* Detailed steps for investigating the `SimpleTab` component, creating the Next.js page, and updating the navigation menu are provided. The plan ensures adherence to Next.js conventions and existing code structure.

#### Code Examples:
* Example implementations for the sample page and the `menuItems` update are included to guide the development process.

#### Scope Clarification:
* This pull request is limited to the planning document (`tasks/Simple