### PR TITLE
Fix issue #59: [Plan] TextFields サンプル追加の計画

### DIFF
--- a/tasks/TextFields.md
+++ b/tasks/TextFields.md
@@ -1,0 +1,34 @@
+# TextFields サンプル追加の計画
+
+## 概要
+TextField コンポーネントの利用方法を明確にするため、BasicTextField および MultilineTextField のサンプルページを追加する計画を立てる。
+
+## 詳細
+- client/nextjs-sample/app/sample-text-field に BasicTextField/MultilineTextField の様々な使い方のサンプルページを作成する。
+- menuItems から新規サンプルページに遷移できるようにする。
+- 必要なファイルや既存 UI/UX への影響調査を行う。
+
+## 具体的な計画内容
+1. サンプルページ作成
+  - client/nextjs-sample/app/sample-text-field ディレクトリを作成し、BasicTextField と MultilineTextField のサンプルコンポーネントを作成する。
+  - それぞれのコンポーネントの基本的な使い方、バリエーション（例: プレースホルダー、エラーメッセージ、制御コンポーネントとしての利用など）を示す。
+
+2. メニューへの追加
+  - client/nextjs-sample/app/layout.tsx の menuItems に新規サンプルページへのリンクを追加する。
+  - ユーザーが簡単にアクセスできるようにする。
+
+3. 影響調査
+  - 既存の UI/UX に影響がないか確認する。
+  - 新規追加によるパフォーマンスやビルドへの影響を調査する。
+
+## 禁止事項
+- 本計画は tasks/TextFields.md のみの作成とし、他のファイルの変更は行わない。
+
+## 参考情報
+- client/common/components/inputs/TextFields/BasicTextField.tsx
+- client/common/components/inputs/TextFields/MultilineTextField.tsx
+- client/nextjs-sample/app/layout.tsx
+
+---
+
+以上が TextField コンポーネントのサンプル追加に関する計画内容です。今後の実装の指針としてご活用ください。


### PR DESCRIPTION
This pull request introduces a new plan to add sample pages for `BasicTextField` and `MultilineTextField` components. The plan is documented in `tasks/TextFields.md` and outlines the steps for creating sample pages, updating navigation, and ensuring no adverse effects on the existing UI/UX.

### Key changes:

#### Documentation for new sample pages:
* Added a detailed plan in `tasks/TextFields.md` to create sample pages for `BasicTextField` and `MultilineTextField` components, including their usage examples and variations (e.g., placeholders, error messages, controlled components).

#### Navigation updates:
* The plan includes adding links to the new sample pages in the `menuItems` section of `client/nextjs-sample/app/layout.tsx` to ensure easy access for users.

#### Impact analysis:
* The plan specifies conducting an impact analysis to confirm that the new additions do not affect existing UI/UX, performance, or build processes.