### PR TITLE
Fix issue #64: [Plan] SimpleRadioGroup コンポーネント追加とサンプル実装計画

### DIFF
--- a/tasks/SimpleRadioGroup.md
+++ b/tasks/SimpleRadioGroup.md
@@ -1,0 +1,24 @@
+# SimpleRadioGroup コンポーネント追加とサンプル実装計画
+
+## 概要
+Material UI の Radio Group をラップした SimpleRadioGroup コンポーネントを新規作成し、再利用可能な形で外部利用を可能にする計画を立案します。また、利用例となるサンプルページとメニューへの追加までを計画します。
+
+## 詳細
+- `client/common/components/Inputs/RadioGroups/SimpleRadioGroup.tsx` を新規作成し、Material UI の Radio Group API をラップしたコンポーネントとする。
+  - 外部からラジオボタンの内容・個数・状態を管理できるようにする。
+  - Material UI のパッケージを直接 import せず、`SimpleRadioGroup.tsx` のみ import すれば使用できるようにする。
+- `client/nextjs-sample/app/sample-radio-group` に `page.tsx` を追加し、SimpleRadioGroup の使い方サンプルを作成。
+- `client/nextjs-sample/app/layout.tsx` の `menuItems` にサンプルページへのリンクを追加し、ナビゲーションから遷移できるようにする。
+
+## 参考
+- [Material UI Radio Button](https://mui.com/material-ui/react-radio-button/)
+
+## 完了条件
+- `tasks/SimpleRadioGroup.md` が日本語で作成されていること
+
+## 禁止事項
+- 本 issue は計画するだけなので、`tasks/SimpleRadioGroup.md` 以外のファイルを変更してはいけません。
+
+---
+
+以上が SimpleRadioGroup コンポーネント追加とサンプル実装の計画詳細です。具体的な実装は別途行います。


### PR DESCRIPTION
This pull request fixes #64.

The issue requested creating a detailed plan for the SimpleRadioGroup component and its usage, documented solely in the `tasks/SimpleRadioGroup.md` file, without modifying any other files. The submitted change adds a comprehensive markdown file that outlines the component creation, its API wrapping Material UI Radio Group, the sample page addition, and menu integration plans. It also clearly states the acceptance criteria and prohibitions, fully meeting the issue’s requirements. Since no other files were changed and the plan is complete and detailed, the issue has been successfully resolved as specified.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌