### PR TITLE
Fix issue #64: [Plan] SimpleRadioGroup コンポーネント追加とサンプル実装計画

### DIFF
--- a/tasks/SimpleRadioGroup.md
+++ b/tasks/SimpleRadioGroup.md
@@ -1,0 +1,32 @@
+# SimpleRadioGroup コンポーネント追加とサンプル実装計画
+
+## 概要
+Material UI の Radio Group をラップした SimpleRadioGroup コンポーネントを新規作成し、再利用可能な形で外部利用を可能にする計画を立案します。また、利用例となるサンプルページとメニューへの追加までを計画します。
+
+## 詳細
+
+1. **SimpleRadioGroup コンポーネント作成**
+   - ファイルパス: `client/common/components/Inputs/RadioGroups/SimpleRadioGroup.tsx`
+   - Material UI の Radio Group API をラップし、外部からラジオボタンの内容・個数・状態を管理できるようにする。
+   - Material UI のパッケージを直接 import せず、SimpleRadioGroup.tsx のみ import すれば使用できる形にする。
+
+2. **サンプルページ作成**
+   - ファイルパス: `client/nextjs-sample/app/sample-radio-group/page.tsx`
+   - SimpleRadioGroup の使い方を示すサンプルページを作成。
+
+3. **メニューへのリンク追加**
+   - ファイルパス: `client/nextjs-sample/app/layout.tsx`
+   - `menuItems` にサンプルページへのリンクを追加し、ナビゲーションから遷移可能にする。
+
+## 参考情報
+- [Material UI Radio Button](https://mui.com/material-ui/react-radio-button/)
+
+## 完了条件
+- 本計画書が日本語で作成されていること
+
+## 禁止事項
+- 本 issue は計画のみを目的とするため、`tasks/SimpleRadioGroup.md` 以外のファイルを変更しないこと
+
+---
+
+以上が SimpleRadioGroup コンポーネント追加とサンプル実装に関する計画の詳細です。


### PR DESCRIPTION
This pull request fixes #64.

The issue requested only the creation of a detailed plan document (`tasks/SimpleRadioGroup.md`) in Japanese, outlining the approach to implement a reusable SimpleRadioGroup component wrapping Material UI's Radio Group, a sample usage page, and a menu link addition. The submitted change adds this markdown file with a clear, structured plan covering all required points: component creation, sample page, menu integration, references, acceptance criteria, and prohibitions. No other files were modified, respecting the prohibition. Therefore, the issue has been successfully resolved as per the acceptance criteria.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌