### PR TITLE
Fix issue #65: [Act] SimpleRadioGroup コンポーネント追加とサンプル実装の実行

### DIFF
--- a/client/common/components/Inputs/RadioGroups/SimpleRadioGroup.tsx
+++ b/client/common/components/Inputs/RadioGroups/SimpleRadioGroup.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+
+export interface SimpleRadioGroupOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface SimpleRadioGroupProps {
+  options: SimpleRadioGroupOption[];
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>, value: string) => void;
+  name?: string;
+  label?: string;
+  row?: boolean;
+  disabled?: boolean;
+}
+
+const SimpleRadioGroup: React.FC<SimpleRadioGroupProps> = ({
+  options,
+  value,
+  onChange,
+  name,
+  label,
+  row = false,
+  disabled = false,
+}) => {
+  return (
+    <FormControl component="fieldset" disabled={disabled}>
+      {label && <FormLabel component="legend">{label}</FormLabel>}
+      <RadioGroup
+        aria-label={name}
+        name={name}
+        value={value}
+        onChange={onChange}
+        row={row}
+      >
+        {options.map((option) => (
+          <FormControlLabel
+            key={option.value}
+            value={option.value}
+            control={<Radio />}
+            label={option.label}
+            disabled={option.disabled}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+};
+
+export default SimpleRadioGroup;

--- a/client/common/components/Inputs/RadioGroups/SimpleRadioGroup.tsx
+++ b/client/common/components/Inputs/RadioGroups/SimpleRadioGroup.tsx
@@ -21,7 +21,23 @@ export interface SimpleRadioGroupProps {
   disabled?: boolean;
 }
 
-const SimpleRadioGroup: React.FC<SimpleRadioGroupProps> = ({
+export interface SimpleRadioGroupOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface SimpleRadioGroupProps {
+  options: SimpleRadioGroupOption[];
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>, value: string) => void;
+  name?: string;
+  label?: string;
+  row?: boolean;
+  disabled?: boolean;
+}
+
+export default function SimpleRadioGroup({
   options,
   value,
   onChange,
@@ -29,7 +45,7 @@ const SimpleRadioGroup: React.FC<SimpleRadioGroupProps> = ({
   label,
   row = false,
   disabled = false,
-}) => {
+}: SimpleRadioGroupProps) {
   return (
     <FormControl component="fieldset" disabled={disabled}>
       {label && <FormLabel component="legend">{label}</FormLabel>}
@@ -52,6 +68,5 @@ const SimpleRadioGroup: React.FC<SimpleRadioGroupProps> = ({
       </RadioGroup>
     </FormControl>
   );
-};
+}
 
-export default SimpleRadioGroup;

--- a/client/nextjs-sample/app/layout.tsx
+++ b/client/nextjs-sample/app/layout.tsx
@@ -33,7 +33,8 @@ async function getMenuItems(): Promise<MenuItemData[]> {
     { title: 'Sample Stacks', url: '/sample-stacks' },
     { title: 'Sample Select', url: '/sample-select' },
     { title: 'Sample Tab', url: '/sample-tab' },
-    { title: 'Sample Text Field', url: '/sample-text-field' }
+    { title: 'Sample Text Field', url: '/sample-text-field' },
+    { title: 'Sample Radio Group', url: '/sample-radio-group' }
   ];
 
   if (session) {

--- a/client/nextjs-sample/app/layout.tsx
+++ b/client/nextjs-sample/app/layout.tsx
@@ -27,7 +27,6 @@ async function getMenuItems(): Promise<MenuItemData[]> {
   const session = await AuthUtil.getServerSession();
 
   const menuItems = [
-  { label: 'Sample Radio Group', path: '/sample-radio-group' },
     { title: 'Home', url: '/' },
     { title: 'Sample Button', url: '/sample-button' },
     { title: 'Sample Date Picker', url: '/sample-date-picker' },

--- a/client/nextjs-sample/app/layout.tsx
+++ b/client/nextjs-sample/app/layout.tsx
@@ -27,6 +27,7 @@ async function getMenuItems(): Promise<MenuItemData[]> {
   const session = await AuthUtil.getServerSession();
 
   const menuItems = [
+  { label: 'Sample Radio Group', path: '/sample-radio-group' },
     { title: 'Home', url: '/' },
     { title: 'Sample Button', url: '/sample-button' },
     { title: 'Sample Date Picker', url: '/sample-date-picker' },

--- a/client/nextjs-sample/app/sample-radio-group/page.tsx
+++ b/client/nextjs-sample/app/sample-radio-group/page.tsx
@@ -23,30 +23,6 @@ export default function SampleRadioGroupPage() {
     <div style={{ padding: 20 }}>
       <h1>SimpleRadioGroup Sample</h1>
 
-      <SimpleRadioGroup
-        options={options1}
-        value={value1}
-        onChange={(e, val) => setValue1(val)}
-        name="group1"
-        label="Group 1"
-      />
-
-      <SimpleRadioGroup
-        options={options2}
-        value={value2}
-        onChange={(e, val) => setValue2(val)}
-        name="group2"
-        label="Group 2"
-        row
-      />
-    </div>
-  );
-}
-
-  return (
-    <div style={{ padding: 20 }}>
-      <h1>SimpleRadioGroup Sample</h1>
-
       <section>
         <h2>Basic Usage</h2>
         <SimpleRadioGroup
@@ -83,5 +59,3 @@ export default function SampleRadioGroupPage() {
     </div>
   );
 };
-
-export default SampleRadioGroupPage;

--- a/client/nextjs-sample/app/sample-radio-group/page.tsx
+++ b/client/nextjs-sample/app/sample-radio-group/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, { useState } from 'react';
+import SimpleRadioGroup, { SimpleRadioGroupOption } from '@client-common/components/Inputs/RadioGroups/SimpleRadioGroup';
+
+const options1: SimpleRadioGroupOption[] = [
+  { label: 'Option 1', value: '1' },
+  { label: 'Option 2', value: '2' },
+  { label: 'Option 3', value: '3' },
+];
+
+const options2: SimpleRadioGroupOption[] = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry', disabled: true },
+];
+
+const SampleRadioGroupPage: React.FC = () => {
+  const [value1, setValue1] = useState('1');
+  const [value2, setValue2] = useState('banana');
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>SimpleRadioGroup Sample</h1>
+
+      <section>
+        <h2>Basic Usage</h2>
+        <SimpleRadioGroup
+          options={options1}
+          value={value1}
+          onChange={(e, val) => setValue1(val)}
+          name="basic"
+          label="Basic Radio Group"
+        />
+      </section>
+
+      <section style={{ marginTop: 40 }}>
+        <h2>With Disabled Option</h2>
+        <SimpleRadioGroup
+          options={options2}
+          value={value2}
+          onChange={(e, val) => setValue2(val)}
+          name="disabled"
+          label="Radio Group with Disabled Option"
+        />
+      </section>
+
+      <section style={{ marginTop: 40 }}>
+        <h2>Row Layout</h2>
+        <SimpleRadioGroup
+          options={options1}
+          value={value1}
+          onChange={(e, val) => setValue1(val)}
+          name="row"
+          label="Row Layout Radio Group"
+          row
+        />
+      </section>
+    </div>
+  );
+};
+
+export default SampleRadioGroupPage;

--- a/client/nextjs-sample/app/sample-radio-group/page.tsx
+++ b/client/nextjs-sample/app/sample-radio-group/page.tsx
@@ -15,9 +15,33 @@ const options2: SimpleRadioGroupOption[] = [
   { label: 'Cherry', value: 'cherry', disabled: true },
 ];
 
-const SampleRadioGroupPage: React.FC = () => {
+export default function SampleRadioGroupPage() {
   const [value1, setValue1] = useState('1');
   const [value2, setValue2] = useState('banana');
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>SimpleRadioGroup Sample</h1>
+
+      <SimpleRadioGroup
+        options={options1}
+        value={value1}
+        onChange={(e, val) => setValue1(val)}
+        name="group1"
+        label="Group 1"
+      />
+
+      <SimpleRadioGroup
+        options={options2}
+        value={value2}
+        onChange={(e, val) => setValue2(val)}
+        name="group2"
+        label="Group 2"
+        row
+      />
+    </div>
+  );
+}
 
   return (
     <div style={{ padding: 20 }}>


### PR DESCRIPTION
This pull request fixes #65.

The PR adds a new `SimpleRadioGroup` component that wraps Material UI's RadioGroup and related components, exposing a simplified API with props for options, value, onChange, and layout control. This satisfies the requirement to create a reusable radio group component without importing Material UI directly elsewhere. A sample page (`sample-radio-group/page.tsx`) demonstrates multiple usage patterns including basic usage, disabled options, and row layout, fulfilling the requirement for usage examples. The menu in `layout.tsx` is updated to include a link to the sample page, enabling navigation from the app menu. These changes collectively meet all acceptance criteria: the component is added, the sample page with multiple patterns is implemented, the menu link is added, and the implementation is clean and straightforward. Therefore, the issue has been successfully resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌