### PR TITLE
Fix issue #65: [Act] SimpleRadioGroup コンポーネント追加とサンプル実装の実行

### DIFF
--- a/client/common/components/inputs/RadioGroups/SimpleRadioGroup.tsx
+++ b/client/common/components/inputs/RadioGroups/SimpleRadioGroup.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+
+export interface SimpleRadioGroupOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface SimpleRadioGroupProps {
+  options: SimpleRadioGroupOption[];
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>, value: string) => void;
+  name?: string;
+  label?: string;
+  row?: boolean;
+  disabled?: boolean;
+}
+
+const SimpleRadioGroup: React.FC<SimpleRadioGroupProps> = ({
+  options,
+  value,
+  onChange,
+  name,
+  label,
+  row = false,
+  disabled = false,
+}) => {
+  return (
+    <FormControl component="fieldset" disabled={disabled}>
+      {label && <FormLabel component="legend">{label}</FormLabel>}
+      <RadioGroup
+        aria-label={name}
+        name={name}
+        value={value}
+        onChange={onChange}
+        row={row}
+      >
+        {options.map((option) => (
+          <FormControlLabel
+            key={option.value}
+            value={option.value}
+            control={<Radio />}
+            label={option.label}
+            disabled={option.disabled}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+};
+
+export default SimpleRadioGroup;

--- a/client/nextjs-sample/app/layout.tsx
+++ b/client/nextjs-sample/app/layout.tsx
@@ -33,7 +33,8 @@ async function getMenuItems(): Promise<MenuItemData[]> {
     { title: 'Sample Stacks', url: '/sample-stacks' },
     { title: 'Sample Select', url: '/sample-select' },
     { title: 'Sample Tab', url: '/sample-tab' },
-    { title: 'Sample Text Field', url: '/sample-text-field' }
+    { title: 'Sample Text Field', url: '/sample-text-field' },
+  { title: 'Sample Radio Group', url: '/sample-radio-group' }
   ];
 
   if (session) {

--- a/client/nextjs-sample/app/sample-radio-group/page.tsx
+++ b/client/nextjs-sample/app/sample-radio-group/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React, { useState } from 'react';
+import SimpleRadioGroup, { SimpleRadioGroupOption } from '@client-common/components/inputs/RadioGroups/SimpleRadioGroup';
+
+const SampleRadioGroupPage: React.FC = () => {
+  const [selectedValue1, setSelectedValue1] = useState('option1');
+  const [selectedValue2, setSelectedValue2] = useState('optionA');
+
+  const options1: SimpleRadioGroupOption[] = [
+    { label: 'Option 1', value: 'option1' },
+    { label: 'Option 2', value: 'option2' },
+    { label: 'Option 3 (disabled)', value: 'option3', disabled: true },
+  ];
+
+  const options2: SimpleRadioGroupOption[] = [
+    { label: 'Option A', value: 'optionA' },
+    { label: 'Option B', value: 'optionB' },
+  ];
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>SimpleRadioGroup Sample</h1>
+
+      <h2>Basic Usage</h2>
+      <SimpleRadioGroup
+        options={options1}
+        value={selectedValue1}
+        onChange={(e, value) => setSelectedValue1(value)}
+        name="sample1"
+        label="Choose an option"
+      />
+
+      <h2>Row Layout</h2>
+      <SimpleRadioGroup
+        options={options2}
+        value={selectedValue2}
+        onChange={(e, value) => setSelectedValue2(value)}
+        name="sample2"
+        label="Choose an option"
+        row
+      />
+
+      <h2>Disabled Group</h2>
+      <SimpleRadioGroup
+        options={options1}
+        value={selectedValue1}
+        onChange={(e, value) => setSelectedValue1(value)}
+        name="sample3"
+        label="Disabled group"
+        disabled
+      />
+    </div>
+  );
+};
+
+export default SampleRadioGroupPage;


### PR DESCRIPTION
This pull request introduces a new reusable `SimpleRadioGroup` component, integrates it into the application, and adds a sample page to demonstrate its usage. The changes focus on enhancing the UI component library and providing an example for developers to reference.

### New Component Addition:

* **Created `SimpleRadioGroup` component**: A reusable React component for rendering radio button groups with support for labels, row layout, and disabled states. (`client/common/components/inputs/RadioGroups/SimpleRadioGroup.tsx`)

### Application Integration:

* **Added a new menu item**: Included a "Sample Radio Group" link in the navigation menu to provide access to the new sample page. (`client/nextjs-sample/app/layout.tsx`)

### Example Page:

* **Implemented `SampleRadioGroupPage`**: A sample page demonstrating the usage of the `SimpleRadioGroup` component with various configurations, such as basic usage, row layout, and disabled groups. (`client/nextjs-sample/app/sample-radio-group/page.tsx`)