### PR TITLE
Fix issue #65: [Act] SimpleRadioGroup コンポーネント追加とサンプル実装の実行

### DIFF
--- a/client/common/components/inputs/RadioGroups/SimpleRadioGroup.tsx
+++ b/client/common/components/inputs/RadioGroups/SimpleRadioGroup.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+
+export interface SimpleRadioGroupOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface SimpleRadioGroupProps {
+  options: SimpleRadioGroupOption[];
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>, value: string) => void;
+  label?: string;
+  name?: string;
+  row?: boolean;
+  disabled?: boolean;
+}
+
+const SimpleRadioGroup: React.FC<SimpleRadioGroupProps> = ({
+  options,
+  value,
+  onChange,
+  label,
+  name,
+  row = false,
+  disabled = false,
+}) => {
+  return (
+    <FormControl component="fieldset" disabled={disabled}>
+      {label && <FormLabel component="legend">{label}</FormLabel>}
+      <RadioGroup
+        aria-label={label}
+        name={name}
+        value={value}
+        onChange={onChange}
+        row={row}
+      >
+        {options.map((option) => (
+          <FormControlLabel
+            key={option.value}
+            value={option.value}
+            control={<Radio />}
+            label={option.label}
+            disabled={option.disabled}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+};
+
+export default SimpleRadioGroup;

--- a/client/nextjs-sample/app/layout.tsx
+++ b/client/nextjs-sample/app/layout.tsx
@@ -33,7 +33,8 @@ async function getMenuItems(): Promise<MenuItemData[]> {
     { title: 'Sample Stacks', url: '/sample-stacks' },
     { title: 'Sample Select', url: '/sample-select' },
     { title: 'Sample Tab', url: '/sample-tab' },
-    { title: 'Sample Text Field', url: '/sample-text-field' }
+    { title: 'Sample Text Field', url: '/sample-text-field' },
+    { title: 'Sample Radio Group', url: '/sample-radio-group' }
   ];
 
   if (session) {

--- a/client/nextjs-sample/app/sample-radio-group/page.tsx
+++ b/client/nextjs-sample/app/sample-radio-group/page.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import SimpleRadioGroup, { SimpleRadioGroupOption } from '../../../common/components/inputs/RadioGroups/SimpleRadioGroup';
+
+const options1: SimpleRadioGroupOption[] = [
+  { label: 'Option 1', value: '1' },
+  { label: 'Option 2', value: '2' },
+  { label: 'Option 3', value: '3' },
+];
+
+const options2: SimpleRadioGroupOption[] = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry', disabled: true },
+];
+
+const SampleRadioGroupPage: React.FC = () => {
+  const [value1, setValue1] = useState('1');
+  const [value2, setValue2] = useState('banana');
+
+  return (
+    <div>
+      <h1>SimpleRadioGroup Sample</h1>
+
+      <section>
+        <h2>Basic Usage</h2>
+        <SimpleRadioGroup
+          label="Basic Options"
+          name="basic"
+          options={options1}
+          value={value1}
+          onChange={(e, val) => setValue1(val)}
+        />
+      </section>
+
+      <section>
+        <h2>With Disabled Option</h2>
+        <SimpleRadioGroup
+          label="Fruits"
+          name="fruits"
+          options={options2}
+          value={value2}
+          onChange={(e, val) => setValue2(val)}
+          row
+        />
+      </section>
+    </div>
+  );
+};
+
+export default SampleRadioGroupPage;


### PR DESCRIPTION
This pull request introduces a new reusable `SimpleRadioGroup` component and integrates it into the application by adding a sample usage page. The changes include the creation of the component, its usage in a new page, and updates to the navigation menu.

### New Component Implementation:
* Created a `SimpleRadioGroup` component in `client/common/components/inputs/RadioGroups/SimpleRadioGroup.tsx`. This component provides a reusable radio group with configurable options, labels, and states such as `disabled` and `row` layout.

### Integration and Usage:
* Added a new page `client/nextjs-sample/app/sample-radio-group/page.tsx` that demonstrates the usage of the `SimpleRadioGroup` component with examples of basic usage and a group with a disabled option.
* Updated the navigation menu in `client/nextjs-sample/app/layout.tsx` to include a link to the new "Sample Radio Group" page.