### PR TITLE
Fix issue #78: [Act] 共通ダイアログ（BasicDialog）追加計画とサンプル連携を実行

### DIFF
--- a/client/common/components/feedback/dialog/BasicDialog.tsx
+++ b/client/common/components/feedback/dialog/BasicDialog.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+
+export type BasicDialogProps = {
+  open: boolean;
+  title?: React.ReactNode;
+  children?: React.ReactNode;
+  onClose: () => void;
+  onConfirm?: () => void;
+  confirmText?: string;
+  cancelText?: string;
+};
+
+export default function BasicDialog({
+  open,
+  title,
+  children,
+  onClose,
+  onConfirm,
+  confirmText = 'OK',
+  cancelText = 'Cancel',
+}: BasicDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} aria-labelledby="basic-dialog-title">
+      {title && <DialogTitle id="basic-dialog-title">{title}</DialogTitle>}
+      <DialogContent dividers>{children}</DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          {cancelText}
+        </Button>
+        {onConfirm && (
+          <Button onClick={onConfirm} color="primary" autoFocus>
+            {confirmText}
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/nextjs-sample/app/sample/dialogs/page.tsx
+++ b/client/nextjs-sample/app/sample/dialogs/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React, { useState } from 'react';
+import BasicDialog from '@client-common/components/feedback/dialog/BasicDialog';
+import ContainedButton from '@client-common/components/inputs/Buttons/ContainedButton';
+
+export default function SampleDialogsPage() {
+  const [open, setOpen] = useState(false);
+  const [dialogContent, setDialogContent] = useState<React.ReactNode>(null);
+  const [dialogTitle, setDialogTitle] = useState<React.ReactNode>('Sample Dialog');
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+  const handleConfirm = () => {
+    alert('Confirmed!');
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <h1>Sample Dialogs</h1>
+      <ContainedButton
+        label="Open Dialog"
+        onClick={() => {
+          setDialogTitle('Sample Dialog Title');
+          setDialogContent(<p>This is a sample dialog content.</p>);
+          handleOpen();
+        }}
+      />
+
+      <BasicDialog
+        open={open}
+        title={dialogTitle}
+        onClose={handleClose}
+        onConfirm={handleConfirm}
+        confirmText="Confirm"
+        cancelText="Cancel"
+      >
+        {dialogContent}
+      </BasicDialog>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a reusable `BasicDialog` component and demonstrates its usage in a sample page. The changes aim to provide a consistent and customizable dialog interface across the application.

### New Component Implementation:

* [`client/common/components/feedback/dialog/BasicDialog.tsx`](diffhunk://#diff-882caa16c69395b27069710537c0367e5a6bca94f9fbb7e5ec516917d16fbdb1R1-R45): Created a reusable `BasicDialog` component with customizable title, content, and actions (confirm and cancel buttons). The component uses Material-UI's `Dialog` and related components for its implementation.

### Sample Page for Demonstration:

* [`client/nextjs-sample/app/sample/dialogs/page.tsx`](diffhunk://#diff-25070b69fbeecf0753c49f9b2ac477e4778082f9889d0c8ff1fbc12960c4cddeR1-R43): Added a sample page (`SampleDialogsPage`) to demonstrate the usage of the `BasicDialog` component. Includes a button to open the dialog and showcases customizable dialog content and actions.