### PR TITLE
Fix issue #78: [Act] 共通ダイアログ（BasicDialog）追加計画とサンプル連携を実行

### DIFF
--- a/client/common/components/BasicDialog.tsx
+++ b/client/common/components/BasicDialog.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+
+interface BasicDialogProps {
+  open: boolean;
+  onClose: () => void;
+  title?: React.ReactNode;
+  children?: React.ReactNode;
+  actions?: React.ReactNode;
+}
+
+const BasicDialog: React.FC<BasicDialogProps> = ({ open, onClose, title, children, actions }) => {
+  return (
+    <Dialog open={open} onClose={onClose} aria-labelledby="basic-dialog-title">
+      {title && <DialogTitle id="basic-dialog-title">{title}</DialogTitle>}
+      <DialogContent dividers>{children}</DialogContent>
+      {actions && <DialogActions>{actions}</DialogActions>}
+    </Dialog>
+  );
+};
+
+export default BasicDialog;

--- a/client/nextjs-sample/app/sample-dialogs.tsx
+++ b/client/nextjs-sample/app/sample-dialogs.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React, { useState } from 'react';
+import BasicDialog from '@client-common/components/BasicDialog';
+import Button from '@mui/material/Button';
+
+const SampleDialogsPage: React.FC = () => {
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  return (
+    <div>
+      <h1>BasicDialog Sample</h1>
+      <Button variant="contained" onClick={handleOpen}>
+        Open Dialog
+      </Button>
+      <BasicDialog
+        open={open}
+        onClose={handleClose}
+        title="Sample Dialog Title"
+        actions={
+          <>
+            <Button onClick={handleClose}>Cancel</Button>
+            <Button onClick={handleClose} variant="contained" color="primary">
+              OK
+            </Button>
+          </>
+        }
+      >
+        <p>This is a sample dialog content.</p>
+      </BasicDialog>
+    </div>
+  );
+};
+
+export default SampleDialogsPage;


### PR DESCRIPTION
This pull request introduces a reusable `BasicDialog` component and demonstrates its usage in a sample page. The changes aim to improve code reusability and provide a consistent dialog design across the application.

### New Component Implementation:

* [`client/common/components/BasicDialog.tsx`](diffhunk://#diff-cd7cf3d2c74a6b9a0a7f7d0f0f1515a18b358fa057e7f299c5a468a118eddf7eR1-R26): Added a new `BasicDialog` component that wraps Material-UI's `Dialog` component, providing a reusable interface with customizable title, content, and actions.

### Usage Example:

* [`client/nextjs-sample/app/sample-dialogs.tsx`](diffhunk://#diff-124f7790d3824d8dacfb02b61bd69ccb04357554b76c079164021dad2eed07b2R1-R38): Created a sample page to demonstrate the usage of the `BasicDialog` component, including a button to open the dialog and example content and actions.