### PR TITLE
Fix issue #86: [Plan] MaterialUI不要で再利用可能な共通テーブルコンポーネント(BasicTable)の追加とサンプル・メニュー連携計画

### DIFF
--- a/tasks/BasicTable.md
+++ b/tasks/BasicTable.md
@@ -1,0 +1,33 @@
+# BasicTable コンポーネント追加計画
+
+## 概要
+MaterialUIに依存しない再利用可能な共通テーブルコンポーネント（BasicTable）を追加し、その利用例を示すサンプル画面の実装とメニュー連携を計画する。
+
+## 方針
+- BasicTableは内部でMaterialUIのTableを利用するが、BasicTable自体はMaterialUIに依存しない設計とする。
+- BasicTableの実装は `client/common/components/data/table/BasicTable.tsx` に行う。
+- サンプル画面は `client/nextjs-sample/app/sample/table/page.tsx` に複数の利用例を実装し、既存の `client/nextjs-sample/app/sample` 配下の部品も活用する。
+- メニュー連携は `client/nextjs-sample/app/layout.tsx` の `menuItems` にテーブルサンプルへのリンクを追加する。
+
+## 調査内容
+- MaterialUIのTableコンポーネントのAPIと使い方を調査。
+- 既存のサンプル画面や共通部品の構成を確認。
+- MaterialUI依存を隠蔽するためのラップ方法を検討。
+
+## 実装例
+- BasicTableはpropsでカラム定義、データ、ページネーション、ソートなどの機能を受け取り、内部でMaterialUIのTableを使って表示。
+- サンプル画面では複数のテーブル例を示し、BasicTableの使い方を明示。
+- メニューにテーブルサンプルへのリンクを追加し、ユーザがアクセスしやすいようにする。
+
+## 今後の課題
+- BasicTableの機能拡張（フィルタリング、カスタムセルレンダリングなど）
+- パフォーマンス最適化
+- アクセシビリティ対応
+
+## 参考情報
+- MaterialUI Table: https://mui.com/material-ui/react-table/
+- 既存のsample/app配下部品
+
+---
+
+以上。


### PR DESCRIPTION
This pull request fixes #86.

The issue required only the creation of a planning document `tasks/BasicTable.md` in Japanese, outlining the approach for adding a reusable BasicTable component without MaterialUI dependency, sample screen implementation, and menu integration. The submitted change adds this markdown file with a comprehensive plan covering the summary, design policy, investigation details, implementation examples, future tasks, and references. No other files were modified, respecting the prohibition. This fully satisfies the acceptance criteria and the issue scope, so the issue is successfully resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌