### PR TITLE
Fix issue #90: [Plan] 共通ダイアログ（ComboBoxAutocomplete）追加とサンプル実装計画

### DIFF
--- a/tasks/ComboBoxAutocomplete.md
+++ b/tasks/ComboBoxAutocomplete.md
@@ -1,0 +1,26 @@
+# ComboBoxAutocomplete 共通ダイアログ追加とサンプル実装計画
+
+## 概要
+MaterialUI を用いた共通ダイアログコンポーネント ComboBoxAutocomplete の追加と、それを活用した複数サンプルの実装計画を行います。
+
+## 詳細
+- `client/common/components/inputs/autocomplete/ComboBoxAutocomplete.tsx` を新規追加し、MaterialUI の Autocomplete をベースとした汎用コンポーネントを設計します。
+  - 他機能で MaterialUI が未導入でも使えるように設計します。
+- `client/nextjs-sample/app/sample/select/page.tsx` を追加し、ComboBoxAutocomplete のさまざまな利用例サンプルを実装します。
+  - 必要があれば `client/nextjs-sample/app/sample` 配下の既存部品も活用します。
+- `client/nextjs-sample/app/layout.tsx` の `menuItems` に select サンプルへのリンクを追加し、画面遷移できるようにします。
+- 計画内容は本ファイル `tasks/ComboBoxAutocomplete.md` に日本語で記載します。
+- 実装例は MaterialUI 公式ドキュメント（https://mui.com/material-ui/react-autocomplete/）を参考にします。
+
+## 完了条件
+- `tasks/ComboBoxAutocomplete.md` が日本語で作成されていること
+
+## 参考情報
+- MaterialUI Autocomplete: https://mui.com/material-ui/react-autocomplete/
+
+## 禁止事項
+- 本 issue は計画するだけなので、`tasks/ComboBoxAutocomplete.md` 以外のファイルを変更してはいけません。
+
+---
+
+以上が ComboBoxAutocomplete 共通ダイアログ追加とサンプル実装の計画内容です。


### PR DESCRIPTION
This pull request fixes #90.

The issue required creating a planning document `tasks/ComboBoxAutocomplete.md` in Japanese that outlines the addition of a common dialog component `ComboBoxAutocomplete` based on MaterialUI Autocomplete, along with plans for sample implementations and navigation updates. The AI agent added this markdown file with a detailed plan covering all specified points: the new component, sample usage, menu link addition, reference to MaterialUI docs, and the prohibition on modifying other files. Since the issue explicitly forbids changes outside this planning file and the agent adhered to this, the acceptance criteria have been fully met by the provided plan. Therefore, the issue is successfully resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌